### PR TITLE
Replace force flag with automatic state reconcili…

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,11 @@ BritzoneBot offers a suite of slash commands to manage breakout rooms. All break
 | Command      | Subcommand     | Description                                                        | Options |
 |--------------|----------------|--------------------------------------------------------------------|---------|
 | `/breakout`  | `create`       | Creates multiple breakout voice channels.                          | `number` *(Integer, Required)* – Number of rooms to create (≥ 1). |
-|              |                |                                                                    | `force` *(Boolean, Optional)* – Force creation even if rooms already exist (deletes existing rooms first). |
 | `/breakout`  | `distribute`   | Previews and distributes users from a main room into breakout rooms. Shows a confirmation prompt before moving. | `mainroom` *(Voice/Stage Channel, Required)* – The source voice channel. |
 |              |                |                                                                    | `exclude` *(String, Optional)* – User mentions to keep in the main room. |
 |              |                |                                                                    | `facilitators` *(String, Optional)* – User mentions to assign into breakout rooms first (one per room when possible). |
-|              |                |                                                                    | `force` *(Boolean, Optional)* – Force redistribution even if users are already distributed. |
 | `/breakout`  | `recall`       | Moves all members from breakout rooms back to the main voice channel. Breakout rooms remain intact. | `mainroom` *(Voice/Stage Channel, Required)* – The destination channel. |
-| `/breakout`  | `delete`       | Deletes all breakout room channels.                                | `force` *(Boolean, Optional)* – Force deletion even if members are still inside. |
+| `/breakout`  | `delete`       | Deletes all breakout room channels.                                | None |
 | `/breakout`  | `timer`        | Sets a countdown timer for the breakout session. Sends a 5-minute warning and a "time's up" message. | `minutes` *(Integer, Required)* – Duration in minutes (≥ 1). |
 | `/breakout`  | `broadcast`    | Broadcasts a message to all active breakout rooms.                 | `message` *(String, Required)* – The message content. |
 | `/breakout`  | `send-message` | Sends a message to a specific voice channel's text chat.           | `channel` *(Voice Channel, Required)* – Target channel. |

--- a/src/commands/main/breakout.ts
+++ b/src/commands/main/breakout.ts
@@ -51,12 +51,6 @@ const command: Command = {
 						.setDescription('Number of breakout rooms to create')
 						.setMinValue(1)
 						.setRequired(true),
-				)
-				.addBooleanOption((option) =>
-					option
-						.setName('force')
-						.setDescription('Force creation even if rooms already exist')
-						.setRequired(false),
 				),
 		)
 		// Distribute subcommand
@@ -91,14 +85,6 @@ const command: Command = {
 							'Facilitators to assign into breakout rooms (mention them with @)',
 						)
 						.setRequired(false),
-				)
-				.addBooleanOption((option) =>
-					option
-						.setName('force')
-						.setDescription(
-							'Force redistribution even if users are already distributed',
-						)
-						.setRequired(false),
 				),
 		)
 		// Recall subcommand
@@ -123,15 +109,7 @@ const command: Command = {
 		.addSubcommand((subcommand) =>
 			subcommand
 				.setName('delete')
-				.setDescription('Delete all breakout room channels')
-				.addBooleanOption((option) =>
-					option
-						.setName('force')
-						.setDescription(
-							'Force deletion even if members are still inside breakout rooms',
-						)
-						.setRequired(false),
-				),
+				.setDescription('Delete all breakout room channels'),
 		)
 		// Timer subcommand
 		.addSubcommand((subcommand) =>

--- a/src/lib/discord/confirm.ts
+++ b/src/lib/discord/confirm.ts
@@ -1,0 +1,119 @@
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	type ChatInputCommandInteraction,
+	ComponentType,
+	MessageFlags,
+} from 'discord.js';
+import { replyOrEdit } from '@/lib/discord/response.js';
+import { logger } from '@/lib/logger.js';
+
+export interface ConfirmActionOptions {
+	interaction: ChatInputCommandInteraction;
+	content: string;
+	confirmLabel: string;
+	cancelLabel?: string;
+	loadingContent?: string;
+	onConfirm: () => Promise<void>;
+	onCancel?: () => Promise<void>;
+	timeMs?: number;
+}
+
+/**
+ * Displays an interactive confirmation prompt with Danger/Cancel buttons
+ * and safely awaits the user's response.
+ */
+export async function confirmAction(
+	options: ConfirmActionOptions,
+): Promise<boolean> {
+	const {
+		interaction,
+		content,
+		confirmLabel,
+		cancelLabel = 'Cancel',
+		loadingContent = '⏳ Processing...',
+		onConfirm,
+		onCancel,
+		timeMs = 60_000,
+	} = options;
+
+	const confirmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+		new ButtonBuilder()
+			.setCustomId('confirm_action')
+			.setLabel(confirmLabel)
+			.setStyle(ButtonStyle.Danger),
+		new ButtonBuilder()
+			.setCustomId('cancel_action')
+			.setLabel(cancelLabel)
+			.setStyle(ButtonStyle.Secondary),
+	);
+
+	const response = await replyOrEdit(interaction, {
+		content,
+		components: [confirmRow],
+	});
+
+	const collector = response.createMessageComponentCollector({
+		componentType: ComponentType.Button,
+		time: timeMs,
+	});
+
+	return new Promise<boolean>((resolve) => {
+		collector.on('collect', async (i) => {
+			try {
+				if (i.user.id !== interaction.user.id) {
+					await i.reply({
+						content: 'You are not authorized to interact with this prompt.',
+						flags: MessageFlags.Ephemeral,
+					});
+					return;
+				}
+
+				if (i.customId === 'cancel_action') {
+					collector.stop('cancelled');
+					await i.update({
+						content: '❌ Action cancelled.',
+						components: [],
+					});
+					if (onCancel) {
+						await onCancel();
+					}
+					resolve(false);
+					return;
+				}
+
+				if (i.customId === 'confirm_action') {
+					collector.stop('confirmed');
+					await i.update({
+						content: loadingContent,
+						components: [],
+					});
+
+					await onConfirm();
+					resolve(true);
+				}
+			} catch (err) {
+				logger.error(
+					{ err },
+					'Failed handling confirmation button interaction',
+				);
+				resolve(false);
+			}
+		});
+
+		collector.on('end', async (_, reason) => {
+			if (reason !== 'confirmed' && reason !== 'cancelled') {
+				try {
+					await interaction.editReply({
+						content: '⏱️ Request timed out.',
+						components: [],
+					});
+				} catch (err) {
+					logger.error({ err }, 'Failed to edit reply on collector timeout');
+				}
+				resolve(false);
+			}
+		});
+	});
+}

--- a/src/modules/breakout/handlers/create.ts
+++ b/src/modules/breakout/handlers/create.ts
@@ -10,12 +10,10 @@ export async function handleCreateCommand(
 	interaction: ChatInputCommandInteraction,
 ): Promise<void> {
 	const numRooms = interaction.options.getInteger('number', true);
-	const force = interaction.options.getBoolean('force') || false;
 	const log = logger.child({
 		subcommand: 'create',
 		guildId: interaction.guildId,
 		numRooms,
-		force,
 	});
 
 	log.info('🔢 Creating breakout rooms');
@@ -23,7 +21,7 @@ export async function handleCreateCommand(
 	await handleInteraction(
 		interaction,
 		async () => {
-			const result = await executeCreate(interaction, numRooms, force);
+			const result = await executeCreate(interaction, numRooms);
 
 			if (result.success) {
 				await replyOrEdit(interaction, result.message);

--- a/src/modules/breakout/handlers/create.ts
+++ b/src/modules/breakout/handlers/create.ts
@@ -1,7 +1,16 @@
-import type { ChatInputCommandInteraction } from 'discord.js';
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	type ChatInputCommandInteraction,
+	ComponentType,
+	MessageFlags,
+} from 'discord.js';
 import { handleInteraction, replyOrEdit } from '@/lib/discord/response.js';
 import { logger } from '@/lib/logger.js';
 import { executeCreate } from '@/modules/breakout/operations/create.js';
+import { hasExistingBreakoutRooms } from '@/modules/breakout/services/room.js';
+import { getMainRoom } from '@/modules/breakout/state/state.js';
 
 /**
  * Handles the create subcommand for breakout rooms
@@ -9,6 +18,8 @@ import { executeCreate } from '@/modules/breakout/operations/create.js';
 export async function handleCreateCommand(
 	interaction: ChatInputCommandInteraction,
 ): Promise<void> {
+	if (!interaction.guildId || !interaction.guild) return;
+
 	const numRooms = interaction.options.getInteger('number', true);
 	const log = logger.child({
 		subcommand: 'create',
@@ -17,6 +28,117 @@ export async function handleCreateCommand(
 	});
 
 	log.info('🔢 Creating breakout rooms');
+
+	const existing = await hasExistingBreakoutRooms(interaction.guild);
+	const mainRoom = getMainRoom(interaction.guild);
+
+	let totalMembers = 0;
+	if (existing.exists) {
+		for (const room of existing.rooms) {
+			if (room.members && room.members.size > 0) {
+				totalMembers += room.members.size;
+			}
+		}
+	}
+
+	// Interactive confirmation if existing rooms have members and no main room is configured
+	if (totalMembers > 0 && !mainRoom) {
+		const confirmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+			new ButtonBuilder()
+				.setCustomId('confirm_create')
+				.setLabel(`Recreate rooms and disconnect ${totalMembers} member(s)`)
+				.setStyle(ButtonStyle.Danger),
+			new ButtonBuilder()
+				.setCustomId('cancel_create')
+				.setLabel('Cancel')
+				.setStyle(ButtonStyle.Secondary),
+		);
+
+		await handleInteraction(
+			interaction,
+			async () => {
+				const response = await replyOrEdit(interaction, {
+					content: `⚠️ ${totalMembers} member(s) are still in existing breakout rooms and no main room is configured. Creating new rooms will disconnect them from voice.`,
+					components: [confirmRow],
+				});
+
+				const collector = response.createMessageComponentCollector({
+					componentType: ComponentType.Button,
+					time: 60_000,
+				});
+
+				await new Promise<void>((resolve) => {
+					collector.on('collect', async (i) => {
+						try {
+							if (i.user.id !== interaction.user.id) {
+								await i.reply({
+									content:
+										'You are not authorized to interact with this prompt.',
+									flags: MessageFlags.Ephemeral,
+								});
+								return;
+							}
+
+							if (i.customId === 'cancel_create') {
+								collector.stop('cancelled');
+								log.info('❌ Room creation cancelled by user');
+								await i.update({
+									content: '❌ Creation cancelled.',
+									components: [],
+								});
+								resolve();
+								return;
+							}
+
+							if (i.customId === 'confirm_create') {
+								collector.stop('confirmed');
+								log.info('✅ Room creation confirmed by user');
+								await i.update({
+									content: '⏳ Creating breakout rooms...',
+									components: [],
+								});
+
+								const result = await executeCreate(interaction, numRooms);
+								if (result.success) {
+									await interaction.editReply({
+										content: result.message,
+										components: [],
+									});
+								} else {
+									await interaction.editReply({
+										content:
+											result.message || 'Failed to create breakout rooms.',
+										components: [],
+									});
+								}
+								resolve();
+							}
+						} catch (err) {
+							log.error({ err }, 'Failed handling create component collector');
+							resolve();
+						}
+					});
+
+					collector.on('end', async (_, reason) => {
+						if (reason !== 'confirmed' && reason !== 'cancelled') {
+							log.warn('⏱️ Create confirmation timed out');
+							try {
+								await interaction.editReply({
+									content: '⏱️ Create request timed out.',
+									components: [],
+								});
+							} catch (err) {
+								log.error({ err }, 'Failed to edit reply on collector timeout');
+							}
+						}
+						resolve();
+					});
+				});
+			},
+			{ deferReply: true, ephemeral: true, handlerTimeoutMs: 120_000 },
+		);
+		return;
+	}
 
 	await handleInteraction(
 		interaction,

--- a/src/modules/breakout/handlers/create.ts
+++ b/src/modules/breakout/handlers/create.ts
@@ -1,11 +1,5 @@
-import {
-	ActionRowBuilder,
-	ButtonBuilder,
-	ButtonStyle,
-	type ChatInputCommandInteraction,
-	ComponentType,
-	MessageFlags,
-} from 'discord.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { confirmAction } from '@/lib/discord/confirm.js';
 import { handleInteraction, replyOrEdit } from '@/lib/discord/response.js';
 import { logger } from '@/lib/logger.js';
 import { executeCreate } from '@/modules/breakout/operations/create.js';
@@ -43,96 +37,28 @@ export async function handleCreateCommand(
 
 	// Interactive confirmation if existing rooms have members and no main room is configured
 	if (totalMembers > 0 && !mainRoom) {
-		const confirmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-			new ButtonBuilder()
-				.setCustomId('confirm_create')
-				.setLabel(`Recreate rooms and disconnect ${totalMembers} member(s)`)
-				.setStyle(ButtonStyle.Danger),
-			new ButtonBuilder()
-				.setCustomId('cancel_create')
-				.setLabel('Cancel')
-				.setStyle(ButtonStyle.Secondary),
-		);
-
 		await handleInteraction(
 			interaction,
 			async () => {
-				const response = await replyOrEdit(interaction, {
+				await confirmAction({
+					interaction,
 					content: `⚠️ ${totalMembers} member(s) are still in existing breakout rooms and no main room is configured. Creating new rooms will disconnect them from voice.`,
-					components: [confirmRow],
-				});
-
-				const collector = response.createMessageComponentCollector({
-					componentType: ComponentType.Button,
-					time: 60_000,
-				});
-
-				await new Promise<void>((resolve) => {
-					collector.on('collect', async (i) => {
-						try {
-							if (i.user.id !== interaction.user.id) {
-								await i.reply({
-									content:
-										'You are not authorized to interact with this prompt.',
-									flags: MessageFlags.Ephemeral,
-								});
-								return;
-							}
-
-							if (i.customId === 'cancel_create') {
-								collector.stop('cancelled');
-								log.info('❌ Room creation cancelled by user');
-								await i.update({
-									content: '❌ Creation cancelled.',
-									components: [],
-								});
-								resolve();
-								return;
-							}
-
-							if (i.customId === 'confirm_create') {
-								collector.stop('confirmed');
-								log.info('✅ Room creation confirmed by user');
-								await i.update({
-									content: '⏳ Creating breakout rooms...',
-									components: [],
-								});
-
-								const result = await executeCreate(interaction, numRooms);
-								if (result.success) {
-									await interaction.editReply({
-										content: result.message,
-										components: [],
-									});
-								} else {
-									await interaction.editReply({
-										content:
-											result.message || 'Failed to create breakout rooms.',
-										components: [],
-									});
-								}
-								resolve();
-							}
-						} catch (err) {
-							log.error({ err }, 'Failed handling create component collector');
-							resolve();
+					confirmLabel: `Recreate rooms and disconnect ${totalMembers} member(s)`,
+					loadingContent: '⏳ Creating breakout rooms...',
+					onConfirm: async () => {
+						const result = await executeCreate(interaction, numRooms);
+						if (result.success) {
+							await interaction.editReply({
+								content: result.message,
+								components: [],
+							});
+						} else {
+							await interaction.editReply({
+								content: result.message || 'Failed to create breakout rooms.',
+								components: [],
+							});
 						}
-					});
-
-					collector.on('end', async (_, reason) => {
-						if (reason !== 'confirmed' && reason !== 'cancelled') {
-							log.warn('⏱️ Create confirmation timed out');
-							try {
-								await interaction.editReply({
-									content: '⏱️ Create request timed out.',
-									components: [],
-								});
-							} catch (err) {
-								log.error({ err }, 'Failed to edit reply on collector timeout');
-							}
-						}
-						resolve();
-					});
+					},
 				});
 			},
 			{ deferReply: true, ephemeral: true, handlerTimeoutMs: 120_000 },

--- a/src/modules/breakout/handlers/delete.ts
+++ b/src/modules/breakout/handlers/delete.ts
@@ -1,11 +1,5 @@
-import {
-	ActionRowBuilder,
-	ButtonBuilder,
-	ButtonStyle,
-	type ChatInputCommandInteraction,
-	ComponentType,
-	MessageFlags,
-} from 'discord.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { confirmAction } from '@/lib/discord/confirm.js';
 import { handleInteraction, replyOrEdit } from '@/lib/discord/response.js';
 import { logger } from '@/lib/logger.js';
 import { executeDelete } from '@/modules/breakout/operations/delete.js';
@@ -38,96 +32,28 @@ export async function handleDeleteCommand(
 
 	// Interactive confirmation if members exist and no main room is configured
 	if (totalMembers > 0 && !mainRoom) {
-		const confirmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-			new ButtonBuilder()
-				.setCustomId('confirm_delete')
-				.setLabel(`Delete and disconnect ${totalMembers} member(s)`)
-				.setStyle(ButtonStyle.Danger),
-			new ButtonBuilder()
-				.setCustomId('cancel_delete')
-				.setLabel('Cancel')
-				.setStyle(ButtonStyle.Secondary),
-		);
-
 		await handleInteraction(
 			interaction,
 			async () => {
-				const response = await replyOrEdit(interaction, {
+				await confirmAction({
+					interaction,
 					content: `⚠️ ${totalMembers} member(s) are still in breakout rooms and no main room is configured. Deleting will disconnect them from voice.`,
-					components: [confirmRow],
-				});
-
-				const collector = response.createMessageComponentCollector({
-					componentType: ComponentType.Button,
-					time: 60_000,
-				});
-
-				await new Promise<void>((resolve) => {
-					collector.on('collect', async (i) => {
-						try {
-							if (i.user.id !== interaction.user.id) {
-								await i.reply({
-									content:
-										'You are not authorized to interact with this prompt.',
-									flags: MessageFlags.Ephemeral,
-								});
-								return;
-							}
-
-							if (i.customId === 'cancel_delete') {
-								collector.stop('cancelled');
-								log.info('❌ Room deletion cancelled by user');
-								await i.update({
-									content: '❌ Deletion cancelled.',
-									components: [],
-								});
-								resolve();
-								return;
-							}
-
-							if (i.customId === 'confirm_delete') {
-								collector.stop('confirmed');
-								log.info('✅ Room deletion confirmed by user');
-								await i.update({
-									content: '⏳ Deleting breakout rooms...',
-									components: [],
-								});
-
-								const result = await executeDelete(interaction);
-								if (result.success) {
-									await interaction.editReply({
-										content: result.message,
-										components: [],
-									});
-								} else {
-									await interaction.editReply({
-										content:
-											result.message || 'Failed to delete breakout rooms.',
-										components: [],
-									});
-								}
-								resolve();
-							}
-						} catch (err) {
-							log.error({ err }, 'Failed handling delete component collector');
-							resolve();
+					confirmLabel: `Delete and disconnect ${totalMembers} member(s)`,
+					loadingContent: '⏳ Deleting breakout rooms...',
+					onConfirm: async () => {
+						const result = await executeDelete(interaction);
+						if (result.success) {
+							await interaction.editReply({
+								content: result.message,
+								components: [],
+							});
+						} else {
+							await interaction.editReply({
+								content: result.message || 'Failed to delete breakout rooms.',
+								components: [],
+							});
 						}
-					});
-
-					collector.on('end', async (_, reason) => {
-						if (reason !== 'confirmed' && reason !== 'cancelled') {
-							log.warn('⏱️ Delete confirmation timed out');
-							try {
-								await interaction.editReply({
-									content: '⏱️ Delete request timed out.',
-									components: [],
-								});
-							} catch (err) {
-								log.error({ err }, 'Failed to edit reply on collector timeout');
-							}
-						}
-						resolve();
-					});
+					},
 				});
 			},
 			{ deferReply: true, ephemeral: true, handlerTimeoutMs: 120_000 },

--- a/src/modules/breakout/handlers/delete.ts
+++ b/src/modules/breakout/handlers/delete.ts
@@ -1,7 +1,14 @@
-import type { ChatInputCommandInteraction } from 'discord.js';
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	type ChatInputCommandInteraction,
+	ComponentType,
+} from 'discord.js';
 import { handleInteraction, replyOrEdit } from '@/lib/discord/response.js';
 import { logger } from '@/lib/logger.js';
 import { executeDelete } from '@/modules/breakout/operations/delete.js';
+import { getMainRoom, getRooms } from '@/modules/breakout/state/state.js';
 
 /**
  * Handles the delete subcommand for breakout rooms
@@ -11,20 +18,114 @@ export async function handleDeleteCommand(
 ): Promise<void> {
 	if (!interaction.guildId || !interaction.guild) return;
 
-	const force = interaction.options.getBoolean('force') || false;
-
 	const log = logger.child({
 		subcommand: 'delete',
 		guildId: interaction.guildId,
-		force,
 	});
 
 	log.info('🎯 Deleting breakout channels');
 
+	const breakoutRooms = getRooms(interaction.guild);
+	const mainRoom = getMainRoom(interaction.guild);
+
+	let totalMembers = 0;
+	for (const room of breakoutRooms) {
+		if (room.members && room.members.size > 0) {
+			totalMembers += room.members.size;
+		}
+	}
+
+	// Interactive confirmation if members exist and no main room is configured
+	if (totalMembers > 0 && !mainRoom) {
+		const confirmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+			new ButtonBuilder()
+				.setCustomId('confirm_delete')
+				.setLabel(`Delete and disconnect ${totalMembers} member(s)`)
+				.setStyle(ButtonStyle.Danger),
+			new ButtonBuilder()
+				.setCustomId('cancel_delete')
+				.setLabel('Cancel')
+				.setStyle(ButtonStyle.Secondary),
+		);
+
+		await handleInteraction(
+			interaction,
+			async () => {
+				const response = await replyOrEdit(interaction, {
+					content: `⚠️ ${totalMembers} member(s) are still in breakout rooms and no main room is configured. Deleting will disconnect them from voice.`,
+					components: [confirmRow],
+				});
+
+				const collector = response.createMessageComponentCollector({
+					componentType: ComponentType.Button,
+					time: 60_000,
+				});
+
+				collector.on('collect', async (i) => {
+					if (i.user.id !== interaction.user.id) {
+						await i.reply({
+							content: 'You are not authorized to interact with this prompt.',
+							ephemeral: true,
+						});
+						return;
+					}
+
+					if (i.customId === 'cancel_delete') {
+						collector.stop('cancelled');
+						log.info('❌ Room deletion cancelled by user');
+						await i.update({
+							content: '❌ Deletion cancelled.',
+							components: [],
+						});
+						return;
+					}
+
+					if (i.customId === 'confirm_delete') {
+						collector.stop('confirmed');
+						log.info('✅ Room deletion confirmed by user');
+						await i.update({
+							content: '⏳ Deleting breakout rooms...',
+							components: [],
+						});
+
+						const result = await executeDelete(interaction);
+						if (result.success) {
+							await interaction.editReply({
+								content: result.message,
+								components: [],
+							});
+						} else {
+							await interaction.editReply({
+								content: result.message || 'Failed to delete breakout rooms.',
+								components: [],
+							});
+						}
+					}
+				});
+
+				collector.on('end', async (_, reason) => {
+					if (reason !== 'confirmed' && reason !== 'cancelled') {
+						log.warn('⏱️ Delete confirmation timed out');
+						try {
+							await interaction.editReply({
+								content: '⏱️ Delete request timed out.',
+								components: [],
+							});
+						} catch (err) {
+							log.error({ err }, 'Failed to edit reply on collector timeout');
+						}
+					}
+				});
+			},
+			{ deferReply: true, ephemeral: true, handlerTimeoutMs: 120_000 },
+		);
+		return;
+	}
+
 	await handleInteraction(
 		interaction,
 		async () => {
-			const result = await executeDelete(interaction, force);
+			const result = await executeDelete(interaction);
 
 			if (result.success) {
 				await replyOrEdit(interaction, result.message);

--- a/src/modules/breakout/handlers/delete.ts
+++ b/src/modules/breakout/handlers/delete.ts
@@ -4,6 +4,7 @@ import {
 	ButtonStyle,
 	type ChatInputCommandInteraction,
 	ComponentType,
+	MessageFlags,
 } from 'discord.js';
 import { handleInteraction, replyOrEdit } from '@/lib/discord/response.js';
 import { logger } from '@/lib/logger.js';
@@ -61,60 +62,72 @@ export async function handleDeleteCommand(
 					time: 60_000,
 				});
 
-				collector.on('collect', async (i) => {
-					if (i.user.id !== interaction.user.id) {
-						await i.reply({
-							content: 'You are not authorized to interact with this prompt.',
-							ephemeral: true,
-						});
-						return;
-					}
-
-					if (i.customId === 'cancel_delete') {
-						collector.stop('cancelled');
-						log.info('❌ Room deletion cancelled by user');
-						await i.update({
-							content: '❌ Deletion cancelled.',
-							components: [],
-						});
-						return;
-					}
-
-					if (i.customId === 'confirm_delete') {
-						collector.stop('confirmed');
-						log.info('✅ Room deletion confirmed by user');
-						await i.update({
-							content: '⏳ Deleting breakout rooms...',
-							components: [],
-						});
-
-						const result = await executeDelete(interaction);
-						if (result.success) {
-							await interaction.editReply({
-								content: result.message,
-								components: [],
-							});
-						} else {
-							await interaction.editReply({
-								content: result.message || 'Failed to delete breakout rooms.',
-								components: [],
-							});
-						}
-					}
-				});
-
-				collector.on('end', async (_, reason) => {
-					if (reason !== 'confirmed' && reason !== 'cancelled') {
-						log.warn('⏱️ Delete confirmation timed out');
+				await new Promise<void>((resolve) => {
+					collector.on('collect', async (i) => {
 						try {
-							await interaction.editReply({
-								content: '⏱️ Delete request timed out.',
-								components: [],
-							});
+							if (i.user.id !== interaction.user.id) {
+								await i.reply({
+									content:
+										'You are not authorized to interact with this prompt.',
+									flags: MessageFlags.Ephemeral,
+								});
+								return;
+							}
+
+							if (i.customId === 'cancel_delete') {
+								collector.stop('cancelled');
+								log.info('❌ Room deletion cancelled by user');
+								await i.update({
+									content: '❌ Deletion cancelled.',
+									components: [],
+								});
+								resolve();
+								return;
+							}
+
+							if (i.customId === 'confirm_delete') {
+								collector.stop('confirmed');
+								log.info('✅ Room deletion confirmed by user');
+								await i.update({
+									content: '⏳ Deleting breakout rooms...',
+									components: [],
+								});
+
+								const result = await executeDelete(interaction);
+								if (result.success) {
+									await interaction.editReply({
+										content: result.message,
+										components: [],
+									});
+								} else {
+									await interaction.editReply({
+										content:
+											result.message || 'Failed to delete breakout rooms.',
+										components: [],
+									});
+								}
+								resolve();
+							}
 						} catch (err) {
-							log.error({ err }, 'Failed to edit reply on collector timeout');
+							log.error({ err }, 'Failed handling delete component collector');
+							resolve();
 						}
-					}
+					});
+
+					collector.on('end', async (_, reason) => {
+						if (reason !== 'confirmed' && reason !== 'cancelled') {
+							log.warn('⏱️ Delete confirmation timed out');
+							try {
+								await interaction.editReply({
+									content: '⏱️ Delete request timed out.',
+									components: [],
+								});
+							} catch (err) {
+								log.error({ err }, 'Failed to edit reply on collector timeout');
+							}
+						}
+						resolve();
+					});
 				});
 			},
 			{ deferReply: true, ephemeral: true, handlerTimeoutMs: 120_000 },

--- a/src/modules/breakout/handlers/distribute.ts
+++ b/src/modules/breakout/handlers/distribute.ts
@@ -4,6 +4,7 @@ import {
 	ButtonStyle,
 	type ChatInputCommandInteraction,
 	ComponentType,
+	MessageFlags,
 	type StageChannel,
 	type VoiceChannel,
 } from 'discord.js';
@@ -79,11 +80,25 @@ export async function handleDistributeCommand(
 		return;
 	}
 
-	const usersInMainRoom = mainRoom.members;
+	// Gather all members from main room and existing breakout rooms
+	const allTargetMembers = new Map<string, import('discord.js').GuildMember>();
+	for (const [id, member] of mainRoom.members) {
+		allTargetMembers.set(id, member);
+	}
+	for (const room of breakoutRooms) {
+		if (room.members && room.members.size > 0) {
+			for (const [id, member] of room.members) {
+				allTargetMembers.set(id, member);
+			}
+		}
+	}
 
-	if (usersInMainRoom.size === 0) {
-		log.warn(`⚠️ No users found in ${mainRoom.name}`);
-		await replyOrEdit(interaction, `There are no users in ${mainRoom.name}.`);
+	if (allTargetMembers.size === 0) {
+		log.warn(`⚠️ No users found in ${mainRoom.name} or breakout rooms`);
+		await replyOrEdit(
+			interaction,
+			`There are no users in ${mainRoom.name} or breakout rooms to distribute.`,
+		);
 		return;
 	}
 
@@ -93,7 +108,7 @@ export async function handleDistributeCommand(
 			const facilitatorMembers: import('discord.js').GuildMember[] = [];
 			const regularMembers: import('discord.js').GuildMember[] = [];
 
-			for (const member of usersInMainRoom.values()) {
+			for (const member of allTargetMembers.values()) {
 				if (excludedUsers.has(member.user.id)) continue;
 				if (facilitators.has(member.user.id)) {
 					facilitatorMembers.push(member);
@@ -123,7 +138,7 @@ export async function handleDistributeCommand(
 				breakoutRooms,
 				facilitators,
 				excludedUsers,
-				usersInMainRoom,
+				usersInMainRoom: mainRoom.members,
 				distribution,
 				isPreview: true,
 			});
@@ -155,91 +170,105 @@ export async function handleDistributeCommand(
 				time: 60_000,
 			});
 
-			collector.on('collect', async (i) => {
-				if (i.user.id !== interaction.user.id) {
-					await i.reply({
-						content:
-							'You are not authorized to interact with this distribution preview.',
-						ephemeral: true,
-					});
-					return;
-				}
-
-				if (i.customId === 'cancel_distribute') {
-					collector.stop('cancelled');
-					log.info('❌ Distribution cancelled by user');
-					await i.update({
-						content: '❌ Distribution cancelled.',
-						embeds: [previewEmbed],
-						components: [],
-					});
-					return;
-				}
-
-				if (i.customId === 'confirm_distribute') {
-					collector.stop('confirmed');
-					log.info('✅ Distribution confirmed by user');
-
-					await i.update({
-						content: '⏳ Distributing users to breakout rooms...',
-						embeds: [previewEmbed],
-						components: [],
-					});
-
-					const result = await executeDistribute(
-						interaction,
-						mainRoom,
-						distribution,
-						facilitators,
-					);
-
-					if (!result.success) {
-						await interaction.editReply({
-							content: `❌ ${result.message}`,
-							embeds: [],
-							components: [],
-						});
-						return;
-					}
-
-					log.debug('📝 Creating final response embed');
-					const finalEmbed = buildDistributionEmbed({
-						mainRoom,
-						breakoutRooms,
-						facilitators,
-						excludedUsers,
-						usersInMainRoom,
-						moveResults: result.moveResults,
-						distribution,
-					});
-
-					log.info('📤 Distribution completed successfully');
-					await interaction.editReply({
-						content: null,
-						embeds: [finalEmbed],
-						components: [],
-					});
-				}
-			});
-
-			collector.on('end', async (_, reason) => {
-				if (reason !== 'confirmed' && reason !== 'cancelled') {
-					log.warn('⏱️ Distribution preview confirmation timed out');
-					const disabledRow =
-						new ActionRowBuilder<ButtonBuilder>().addComponents(
-							confirmButton.setDisabled(true),
-							cancelButton.setDisabled(true),
-						);
+			await new Promise<void>((resolve) => {
+				collector.on('collect', async (i) => {
 					try {
-						await interaction.editReply({
-							content: '⏱️ Distribution request timed out.',
-							embeds: [previewEmbed],
-							components: [disabledRow],
-						});
+						if (i.user.id !== interaction.user.id) {
+							await i.reply({
+								content:
+									'You are not authorized to interact with this distribution preview.',
+								flags: MessageFlags.Ephemeral,
+							});
+							return;
+						}
+
+						if (i.customId === 'cancel_distribute') {
+							collector.stop('cancelled');
+							log.info('❌ Distribution cancelled by user');
+							await i.update({
+								content: '❌ Distribution cancelled.',
+								embeds: [previewEmbed],
+								components: [],
+							});
+							resolve();
+							return;
+						}
+
+						if (i.customId === 'confirm_distribute') {
+							collector.stop('confirmed');
+							log.info('✅ Distribution confirmed by user');
+
+							await i.update({
+								content: '⏳ Distributing users to breakout rooms...',
+								embeds: [previewEmbed],
+								components: [],
+							});
+
+							const result = await executeDistribute(
+								interaction,
+								mainRoom,
+								distribution,
+								facilitators,
+							);
+
+							if (!result.success) {
+								await interaction.editReply({
+									content: `❌ ${result.message}`,
+									embeds: [],
+									components: [],
+								});
+								resolve();
+								return;
+							}
+
+							log.debug('📝 Creating final response embed');
+							const finalEmbed = buildDistributionEmbed({
+								mainRoom,
+								breakoutRooms,
+								facilitators,
+								excludedUsers,
+								usersInMainRoom: mainRoom.members,
+								moveResults: result.moveResults,
+								distribution,
+							});
+
+							log.info('📤 Distribution completed successfully');
+							await interaction.editReply({
+								content: null,
+								embeds: [finalEmbed],
+								components: [],
+							});
+							resolve();
+						}
 					} catch (err) {
-						log.error({ err }, 'Failed to edit reply on collector timeout');
+						log.error(
+							{ err },
+							'Failed handling distribute component collector',
+						);
+						resolve();
 					}
-				}
+				});
+
+				collector.on('end', async (_, reason) => {
+					if (reason !== 'confirmed' && reason !== 'cancelled') {
+						log.warn('⏱️ Distribution preview confirmation timed out');
+						const disabledRow =
+							new ActionRowBuilder<ButtonBuilder>().addComponents(
+								confirmButton.setDisabled(true),
+								cancelButton.setDisabled(true),
+							);
+						try {
+							await interaction.editReply({
+								content: '⏱️ Distribution request timed out.',
+								embeds: [previewEmbed],
+								components: [disabledRow],
+							});
+						} catch (err) {
+							log.error({ err }, 'Failed to edit reply on collector timeout');
+						}
+					}
+					resolve();
+				});
 			});
 		},
 		{ deferReply: true, ephemeral: true, handlerTimeoutMs: 120_000 },

--- a/src/modules/breakout/handlers/distribute.ts
+++ b/src/modules/breakout/handlers/distribute.ts
@@ -36,13 +36,11 @@ export async function handleDistributeCommand(
 
 	const excludeInput = interaction.options.getString('exclude');
 	const facilitatorsInput = interaction.options.getString('facilitators');
-	const force = interaction.options.getBoolean('force') || false;
 
 	const log = logger.child({
 		subcommand: 'distribute',
 		guildId: interaction.guildId,
 		mainRoom: mainRoom.name,
-		force,
 	});
 	log.info('🎯 Main room selected');
 
@@ -192,7 +190,6 @@ export async function handleDistributeCommand(
 						interaction,
 						mainRoom,
 						distribution,
-						force,
 						facilitators,
 					);
 

--- a/src/modules/breakout/operations/create.ts
+++ b/src/modules/breakout/operations/create.ts
@@ -1,9 +1,11 @@
 import {
 	ChannelType,
 	type CommandInteraction,
+	type StageChannel,
 	type VoiceChannel,
 } from 'discord.js';
 import { logger } from '@/lib/logger.js';
+import { moveUserToRoom } from '@/modules/breakout/services/distribution.js';
 import {
 	createRoom,
 	deleteRoom,
@@ -14,6 +16,7 @@ import {
 	completeOperation,
 	getCompletedSteps,
 	getCurrentOperation,
+	getMainRoom,
 	startOperation,
 	storeRoomIds,
 	updateProgress,
@@ -26,7 +29,6 @@ import type { OperationResult } from '@/types/index.js';
 export async function executeCreate(
 	interaction: CommandInteraction,
 	numRooms: number,
-	force: boolean = false,
 ): Promise<OperationResult> {
 	const guildId = interaction.guildId;
 	if (!guildId || !interaction.guild) {
@@ -41,7 +43,6 @@ export async function executeCreate(
 		operation: operationType,
 		guildId,
 		numRooms,
-		force,
 	});
 
 	// Check if we are resuming an interrupted operation
@@ -51,27 +52,45 @@ export async function executeCreate(
 	if (isResuming) {
 		log.info(`🔄 Resuming create operation`);
 	} else {
-		// Check for existing breakout rooms
+		// Check for existing breakout rooms and auto-reconcile
 		const existingRooms = await hasExistingBreakoutRooms(interaction.guild);
-		if (existingRooms.exists && !force) {
-			return {
-				success: false,
-				message: `There are already ${existingRooms.rooms.length} breakout rooms in this server. Use '/breakout create' with the force flag set to true to replace them, or '/breakout delete' first to clean up existing rooms.`,
-			};
-		}
 
-		// If force is true and rooms exist, cleanup first
-		if (force && existingRooms.exists) {
-			log.info(
-				{ existingCount: existingRooms.rooms.length },
-				`🔄 Force flag enabled, cleaning up existing rooms`,
+		if (existingRooms.exists) {
+			const occupiedRooms = existingRooms.rooms.filter(
+				(r) => r.members && r.members.size > 0,
 			);
-			// Simple cleanup: delete rooms.
-			// Note: Ideally we would move users back to main room if known, but for simplicity/force we just delete.
+
+			if (occupiedRooms.length > 0) {
+				const mainRoom = getMainRoom(interaction.guild);
+				if (mainRoom && mainRoom.isVoiceBased()) {
+					for (const room of occupiedRooms) {
+						for (const member of room.members.values()) {
+							try {
+								await moveUserToRoom(
+									member,
+									mainRoom as VoiceChannel | StageChannel,
+								);
+							} catch (err) {
+								log.warn(
+									{ memberId: member.id, err },
+									'Failed to move user to main room during create cleanup',
+								);
+							}
+						}
+					}
+				}
+				// If no main room is stored, just delete the channels —
+				// Discord will disconnect occupants from voice.
+			}
+
 			for (const room of existingRooms.rooms) {
 				await deleteRoom(room);
 			}
-			clearSession(guildId);
+			await clearSession(guildId);
+			log.info(
+				{ cleaned: existingRooms.rooms.length },
+				'♻️ Cleaned existing rooms before create',
+			);
 		}
 
 		// Start new operation

--- a/src/modules/breakout/operations/create.ts
+++ b/src/modules/breakout/operations/create.ts
@@ -49,55 +49,62 @@ export async function executeCreate(
 	const currentOp = await getCurrentOperation(guildId);
 	const isResuming = currentOp?.type === operationType;
 
-	if (isResuming) {
-		log.info(`🔄 Resuming create operation`);
-	} else {
-		// Check for existing breakout rooms and auto-reconcile
-		const existingRooms = await hasExistingBreakoutRooms(interaction.guild);
+	try {
+		if (isResuming) {
+			log.info(`🔄 Resuming create operation`);
+		} else {
+			// Check for existing breakout rooms and auto-reconcile
+			const existingRooms = await hasExistingBreakoutRooms(interaction.guild);
 
-		if (existingRooms.exists) {
-			const occupiedRooms = existingRooms.rooms.filter(
-				(r) => r.members && r.members.size > 0,
-			);
+			if (existingRooms.exists) {
+				const occupiedRooms = existingRooms.rooms.filter(
+					(r) => r.members && r.members.size > 0,
+				);
 
-			if (occupiedRooms.length > 0) {
-				const mainRoom = getMainRoom(interaction.guild);
-				if (mainRoom && mainRoom.isVoiceBased()) {
-					for (const room of occupiedRooms) {
-						for (const member of room.members.values()) {
-							try {
-								await moveUserToRoom(
-									member,
-									mainRoom as VoiceChannel | StageChannel,
-								);
-							} catch (err) {
-								log.warn(
-									{ memberId: member.id, err },
-									'Failed to move user to main room during create cleanup',
-								);
+				if (occupiedRooms.length > 0) {
+					const mainRoom = getMainRoom(interaction.guild);
+					if (mainRoom) {
+						for (const room of occupiedRooms) {
+							for (const member of room.members.values()) {
+								try {
+									await moveUserToRoom(
+										member,
+										mainRoom as VoiceChannel | StageChannel,
+									);
+								} catch (err) {
+									log.warn(
+										{ memberId: member.id, err },
+										'Failed to move user to main room during create cleanup',
+									);
+								}
 							}
 						}
 					}
+					// If no main room is stored, just delete the channels —
+					// Discord will disconnect occupants from voice.
 				}
-				// If no main room is stored, just delete the channels —
-				// Discord will disconnect occupants from voice.
+
+				for (const room of existingRooms.rooms) {
+					try {
+						await deleteRoom(room);
+					} catch (err) {
+						log.warn(
+							{ roomId: room.id, err },
+							'Failed to delete existing room during cleanup',
+						);
+					}
+				}
+				await clearSession(guildId);
+				log.info(
+					{ cleaned: existingRooms.rooms.length },
+					'♻️ Cleaned existing rooms before create',
+				);
 			}
 
-			for (const room of existingRooms.rooms) {
-				await deleteRoom(room);
-			}
-			await clearSession(guildId);
-			log.info(
-				{ cleaned: existingRooms.rooms.length },
-				'♻️ Cleaned existing rooms before create',
-			);
+			// Start new operation
+			await startOperation(guildId, operationType, { numRooms });
 		}
 
-		// Start new operation
-		await startOperation(guildId, operationType, { numRooms });
-	}
-
-	try {
 		const createdChannels: VoiceChannel[] = [];
 
 		// Fetch completed steps once before the loop for efficiency

--- a/src/modules/breakout/operations/delete.ts
+++ b/src/modules/breakout/operations/delete.ts
@@ -1,15 +1,18 @@
 import {
 	ChannelType,
 	type CommandInteraction,
+	type StageChannel,
 	type VoiceChannel,
 } from 'discord.js';
 import { logger } from '@/lib/logger.js';
+import { moveUserToRoom } from '@/modules/breakout/services/distribution.js';
 import { deleteRoom } from '@/modules/breakout/services/room.js';
 import {
 	clearSession,
 	completeOperation,
 	getCompletedSteps,
 	getCurrentOperation,
+	getMainRoom,
 	getRooms,
 	startOperation,
 	updateProgress,
@@ -21,7 +24,6 @@ import type { OperationResult } from '@/types/index.js';
  */
 export async function executeDelete(
 	interaction: CommandInteraction,
-	force: boolean = false,
 ): Promise<OperationResult> {
 	const guildId = interaction.guildId;
 	if (!guildId || !interaction.guild) {
@@ -35,7 +37,6 @@ export async function executeDelete(
 	const log = logger.child({
 		operation: operationType,
 		guildId,
-		force,
 	});
 
 	// Check if we are resuming an interrupted operation
@@ -79,33 +80,42 @@ export async function executeDelete(
 			};
 		}
 
-		// Check if any rooms still have members inside
-		let totalMembers = 0;
+		// Auto-recall members to main room if one is configured
+		const mainRoom = getMainRoom(interaction.guild);
+		let membersRecalled = 0;
+
 		for (const room of breakoutRooms) {
 			const guildRoom = interaction.guild.channels.cache.get(room.id) as
 				| VoiceChannel
 				| undefined;
 			if (guildRoom?.members && guildRoom.members.size > 0) {
-				totalMembers += guildRoom.members.size;
+				for (const member of guildRoom.members.values()) {
+					if (mainRoom && mainRoom.isVoiceBased()) {
+						try {
+							await moveUserToRoom(
+								member,
+								mainRoom as VoiceChannel | StageChannel,
+							);
+							membersRecalled++;
+						} catch (err) {
+							log.warn(
+								{ memberId: member.id, err },
+								'Failed to move user to main room during delete',
+							);
+						}
+					}
+					// If no main room, Discord handles disconnect on channel delete
+				}
 			}
 		}
 
-		if (totalMembers > 0 && !force) {
-			log.warn(
-				{ totalMembers },
-				'⚠️ Refusing to delete: breakout rooms still have members inside.',
-			);
-			return {
-				success: false,
-				message:
-					"Breakout rooms still have members inside! Use '/breakout recall' first to move them back, or run '/breakout delete' with the force flag set to true to delete anyway.",
-			};
+		if (membersRecalled > 0) {
+			log.info({ membersRecalled }, '♻️ Recalled members before deleting rooms');
 		}
 
 		// Start new operation
 		if (!isResuming) {
 			await startOperation(guildId, operationType, {
-				force,
 				roomIds: breakoutRooms.map((room) => room.id),
 			});
 

--- a/src/modules/breakout/operations/delete.ts
+++ b/src/modules/breakout/operations/delete.ts
@@ -80,39 +80,6 @@ export async function executeDelete(
 			};
 		}
 
-		// Auto-recall members to main room if one is configured
-		const mainRoom = getMainRoom(interaction.guild);
-		let membersRecalled = 0;
-
-		for (const room of breakoutRooms) {
-			const guildRoom = interaction.guild.channels.cache.get(room.id) as
-				| VoiceChannel
-				| undefined;
-			if (guildRoom?.members && guildRoom.members.size > 0) {
-				for (const member of guildRoom.members.values()) {
-					if (mainRoom && mainRoom.isVoiceBased()) {
-						try {
-							await moveUserToRoom(
-								member,
-								mainRoom as VoiceChannel | StageChannel,
-							);
-							membersRecalled++;
-						} catch (err) {
-							log.warn(
-								{ memberId: member.id, err },
-								'Failed to move user to main room during delete',
-							);
-						}
-					}
-					// If no main room, Discord handles disconnect on channel delete
-				}
-			}
-		}
-
-		if (membersRecalled > 0) {
-			log.info({ membersRecalled }, '♻️ Recalled members before deleting rooms');
-		}
-
 		// Start new operation
 		if (!isResuming) {
 			await startOperation(guildId, operationType, {
@@ -124,6 +91,39 @@ export async function executeDelete(
 				'🔍 Found breakout room(s) to delete',
 			);
 		}
+	}
+
+	// Auto-recall members to main room if one is configured (runs on both initial run and resume)
+	const mainRoom = getMainRoom(interaction.guild);
+	let membersRecalled = 0;
+
+	for (const room of breakoutRooms) {
+		const guildRoom = interaction.guild.channels.cache.get(room.id) as
+			| VoiceChannel
+			| undefined;
+		if (guildRoom?.members && guildRoom.members.size > 0) {
+			for (const member of guildRoom.members.values()) {
+				if (mainRoom) {
+					try {
+						await moveUserToRoom(
+							member,
+							mainRoom as VoiceChannel | StageChannel,
+						);
+						membersRecalled++;
+					} catch (err) {
+						log.warn(
+							{ memberId: member.id, err },
+							'Failed to move user to main room during delete',
+						);
+					}
+				}
+				// If no main room, Discord handles disconnect on channel delete
+			}
+		}
+	}
+
+	if (membersRecalled > 0) {
+		log.info({ membersRecalled }, '♻️ Recalled members before deleting rooms');
 	}
 
 	const totalRooms = breakoutRooms.length;

--- a/src/modules/breakout/operations/distribute.ts
+++ b/src/modules/breakout/operations/distribute.ts
@@ -13,7 +13,6 @@ import {
 	completeOperation,
 	getCompletedSteps,
 	getCurrentOperation,
-	getMainRoom,
 	getRooms,
 	setMainRoomId,
 	startOperation,
@@ -109,23 +108,20 @@ export async function executeDistribute(
 		const isDistributionActive = await hasActiveDistribution(interaction.guild);
 
 		if (isDistributionActive) {
-			const targetMainRoom = mainRoom || getMainRoom(interaction.guild);
-			if (targetMainRoom && targetMainRoom.isVoiceBased()) {
-				const rooms = getRooms(interaction.guild);
-				for (const room of rooms) {
-					if (room.members && room.members.size > 0) {
-						for (const member of room.members.values()) {
-							try {
-								await moveUserToRoom(
-									member,
-									targetMainRoom as VoiceChannel | StageChannel,
-								);
-							} catch (err) {
-								log.warn(
-									{ memberId: member.id, err },
-									'Failed to move user during auto-recall before redistributing',
-								);
-							}
+			const rooms = getRooms(interaction.guild);
+			for (const room of rooms) {
+				if (room.members && room.members.size > 0) {
+					for (const member of room.members.values()) {
+						try {
+							await moveUserToRoom(
+								member,
+								mainRoom as VoiceChannel | StageChannel,
+							);
+						} catch (err) {
+							log.warn(
+								{ memberId: member.id, err },
+								'Failed to move user during auto-recall before redistributing',
+							);
 						}
 					}
 				}

--- a/src/modules/breakout/operations/distribute.ts
+++ b/src/modules/breakout/operations/distribute.ts
@@ -1,5 +1,6 @@
 import type {
 	CommandInteraction,
+	StageChannel,
 	VoiceBasedChannel,
 	VoiceChannel,
 } from 'discord.js';
@@ -12,6 +13,8 @@ import {
 	completeOperation,
 	getCompletedSteps,
 	getCurrentOperation,
+	getMainRoom,
+	getRooms,
 	setMainRoomId,
 	startOperation,
 	updateProgress,
@@ -27,7 +30,6 @@ export async function executeDistribute(
 	interaction: CommandInteraction,
 	mainRoom: VoiceBasedChannel,
 	distribution: UserDistribution,
-	force: boolean = false,
 	facilitators?: Set<string>,
 ): Promise<OperationResult> {
 	const guildId = interaction.guildId;
@@ -42,7 +44,6 @@ export async function executeDistribute(
 	const log = logger.child({
 		operation: operationType,
 		guildId,
-		force,
 	});
 
 	// Check if we are resuming an interrupted operation
@@ -104,20 +105,32 @@ export async function executeDistribute(
 			}
 		}
 	} else {
-		// Check if distribution is already active
+		// Check if distribution is already active and recall users first
 		const isDistributionActive = await hasActiveDistribution(interaction.guild);
-		if (isDistributionActive && !force) {
-			return {
-				success: false,
-				message:
-					"Users are already distributed to breakout rooms. Use '/breakout distribute' with the force flag set to true to redistribute, or use '/breakout recall' to move users back.",
-			};
-		}
 
-		if (force && isDistributionActive) {
-			log.info(
-				`🔄 Force flag enabled, proceeding with redistribution (previous session implicit end)`,
-			);
+		if (isDistributionActive) {
+			const targetMainRoom = mainRoom || getMainRoom(interaction.guild);
+			if (targetMainRoom && targetMainRoom.isVoiceBased()) {
+				const rooms = getRooms(interaction.guild);
+				for (const room of rooms) {
+					if (room.members && room.members.size > 0) {
+						for (const member of room.members.values()) {
+							try {
+								await moveUserToRoom(
+									member,
+									targetMainRoom as VoiceChannel | StageChannel,
+								);
+							} catch (err) {
+								log.warn(
+									{ memberId: member.id, err },
+									'Failed to move user during auto-recall before redistributing',
+								);
+							}
+						}
+					}
+				}
+			}
+			log.info('♻️ Recalled existing distribution before redistributing');
 		}
 
 		// Store distribution plan for recovery


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breakout rooms are now automatically cleaned up before creating or redistributing rooms.
  * Members are returned to the main room when available.
  * Deleting rooms with remaining members now offers an authorized confirmation flow.

* **Changes**
  * Removed the `force` option from breakout create, distribute, and delete commands.
  * Added handling for cancellations, timeouts, and individual member move failures during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->